### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # week-5-sorting-and-searching-questions-mcraft3
 week-5-sorting-and-searching-questions-mcraft3 created by GitHub Classroom
 
+Sun 0021 EST.
+I updated the demo on line 364, 365 and 366 to usekey35 and value pig to match the previous update to replace key 55 with 35. By doing that an above demo of  .put of key forces a rehash. Previously do to the resize function there was no actual demonstration of resize so I updated a few keys to show the rehash. I forget to update these 3 demo lines to now use key 35 as key 55 no longer existed. This makes all the demo work properly. There was no change to the hash table code it is good and runs good. v/r Mike
+
 Sat 1256 EST. 
 
 @mcraft3


### PR DESCRIPTION
I updated the demo on line 364, 365 and 366 to usekey35 and value pig to match the previous update to replace key 55 with 35. By doing that an above demo of  .put of key forces a rehash. Previously do to the resize function there was no actual demonstration of resize so I updated a few keys to show the rehash. I forget to update these 3 demo lines to now use key 35 as key 55 no longer existed. This makes all the demo work properly. There was no change to the hash table code it is good and runs good. 

This is final. the one video on my iphone will walk thru the code. The second video will run the code and demo the outputs with this one minor change.

v/r Mike